### PR TITLE
EG-16509 finish cloud run domain mapping integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ create_dns = false
 
 If you decide to manually set up a custom domain for your Cloud Run service, follow Google's instructions for [Mapping customer domains](https://cloud.google.com/run/docs/mapping-custom-domains#run)
 
+Note: Provisioning of TLS certificates in Google will take some time. You can use `gcloud beta run domain-mappings describe --domain $SUBDOMAIN.$DOMAIN` to inspect progress of the provisioning.
+
 #### Instance Sized
 
 Configure the CPU & memory limits for your Cloud Run instances by adding the following variables to your Terraform module

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -26,5 +26,11 @@ resource "google_dns_record_set" "superblocks" {
   name         = "${var.record_name}.${local.dns_name}"
   ttl          = 300
   type         = "CNAME"
-  rrdatas      = ["${var.record_name}.${local.dns_name}"]
+
+  rrdatas = flatten([
+    for _, status in google_cloud_run_domain_mapping.superblocks.status: [
+      for _, rrs in status.resource_records:
+      rrs.rrdata
+    ]
+  ])
 }


### PR DESCRIPTION
Create the google_dns_record_set CNAME with the resource records from the
google_cloud_run_domain_mapping so that Cloud Run mappings can provision
the TLS certificate and the CNAME actually functions.